### PR TITLE
Fix typos in source comments

### DIFF
--- a/sources/luxembourg-caclr-dicacolo.py
+++ b/sources/luxembourg-caclr-dicacolo.py
@@ -19,7 +19,7 @@ def get():
     )
 
     # Downloading the CACLR might take ~15 seconds.
-    # In the meanwile, shake your wrists and correct your posture.
+    # In the meanwhile, shake your wrists and correct your posture.
     r = requests.get(CACLR_ZIP)
     zipfile = ZipFile(BytesIO(r.content))
     # zip_names = zipfile.namelist()

--- a/sources/luxembourg_addresses.py
+++ b/sources/luxembourg_addresses.py
@@ -16,7 +16,7 @@ def get():
         "https://data.public.lu/fr/datasets/r/5cadc5b8-6a7d-4283-87bc-f9e58dd771f7"
     )
     # Downloading the addresses might take ~15 seconds.
-    # In the meanwile, shake your wrists and correct your posture.
+    # In the meanwhile, shake your wrists and correct your posture.
     r = requests.get(ADDRESSES_CSV)
     r.encoding = "utf-8-sig"
     req_addresses = r.text.splitlines()


### PR DESCRIPTION
## Summary
- fix typo in luxembourg address comments
- fix typo in caclr address comments

## Testing
- `python3 -m py_compile sources/luxembourg_addresses.py sources/luxembourg-caclr-dicacolo.py`
- `python3 csventrifuge.py --help | head`

------
https://chatgpt.com/codex/tasks/task_e_68442ffbe060832f9742eb06c8162b7d