### PR TITLE
Fix rule lookup with None values

### DIFF
--- a/csventrifuge.py
+++ b/csventrifuge.py
@@ -245,16 +245,18 @@ for row in data:
 
         # apply rules
         orig = row.get(key)
-        try:
+        if (
+            orig is not None
+            and rulebook.get(key) is not None
+            and orig in rulebook[key]
+        ):
+            row[key] = rulebook[key][orig][0]
+            log.debug("Rule: replacing [%s] %s with %s", key, orig, row[key])
+            rulebook[key][orig][1] += 1
+            substitutions += 1
+        else:
             if orig is not None:
-                row[key] = rulebook[key][orig][0]
-                log.debug("Rule: replacing [%s] %s with %s", key, orig, row[key])
-                rulebook[key][orig][1] += 1
-                substitutions += 1
-            else:
-                raise KeyError
-        except KeyError:
-            log.debug("No rule for [%s] %s", key, orig)
+                log.debug("No rule for [%s] %s", key, orig)
 
         # apply enhancement
         try:

--- a/sources/test_source.py
+++ b/sources/test_source.py
@@ -1,0 +1,4 @@
+# Minimal test source returning a single row with missing value
+
+def get():
+    return [{"foo": None}], ["foo"]

--- a/tests/test_no_rule_for_none.py
+++ b/tests/test_no_rule_for_none.py
@@ -1,0 +1,26 @@
+import os
+import runpy
+import sys
+import tempfile
+import logging
+import unittest
+from unittest import mock
+
+
+class TestNoRuleForNone(unittest.TestCase):
+    def test_no_log_when_value_none(self):
+        tmp = tempfile.NamedTemporaryFile(delete=False)
+        tmp.close()
+        script_path = os.path.join(os.path.dirname(__file__), os.pardir)
+        sys.path.insert(0, script_path)
+        argv = ["csventrifuge.py", "test_source", tmp.name]
+        with mock.patch.object(sys, "argv", argv):
+            logging.basicConfig(level=logging.DEBUG)
+            with self.assertLogs("__main__", level="DEBUG") as cm:
+                runpy.run_module("csventrifuge", run_name="__main__")
+        os.unlink(tmp.name)
+        self.assertNotIn("No rule for [foo] None", "\n".join(cm.output))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- avoid accessing rulebook when the original value is missing
- only log missing rules when a value was present
- add minimal source module for testing
- add regression test for missing rule handling

## Testing
- `python -m unittest discover -s tests -v`

------
https://chatgpt.com/codex/tasks/task_e_684456f11038832fb38efc6c9298b1ec