### PR TITLE
Refactor entry classes and cleanup

### DIFF
--- a/tests/test_loading_helpers.py
+++ b/tests/test_loading_helpers.py
@@ -4,7 +4,7 @@ import csventrifuge
 def test_load_rules_single_file():
     rules = csventrifuge.load_rules("luxembourg_addresses", ["rue"])
     assert "rue" in rules
-    assert rules["rue"]["A la Croix Saint Pierre"].replacement == "À la Croix Saint-Pierre"
+    assert rules["rue"]["A la Croix Saint Pierre"].value == "À la Croix Saint-Pierre"
     assert rules["rue"]["A la Croix Saint Pierre"].count == 0
 
 
@@ -13,7 +13,7 @@ def test_load_enhancements_multiple_targets():
     book, enhanced = csventrifuge.load_enhancements("luxembourg_addresses", keys)
     assert "id_caclr_bat" in book
     assert "rue" in book["id_caclr_bat"]
-    assert book["id_caclr_bat"]["rue"]["79281"].replacement == "Rue des Jardins"
+    assert book["id_caclr_bat"]["rue"]["79281"].value == "Rue des Jardins"
     assert book["id_caclr_bat"]["rue"]["79281"].count == 0
     assert "rue" in enhanced and "id_caclr_rue" in enhanced
 


### PR DESCRIPTION
## Summary
- use a single `Entry` dataclass for rules, enhancements and filters
- rename argument in `is_valid_source` to avoid shadowing
- iterate rulebook with `.items()`
- run ruff and black

## Testing
- `ruff check csventrifuge.py tests/test_loading_helpers.py`
- `black -q csventrifuge.py tests/test_loading_helpers.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6844dc8fad44832f9e62e7ce9ad97773