### PR TITLE
Fix Luxembourg addresses fetch

### DIFF
--- a/sources/luxembourg_addresses.py
+++ b/sources/luxembourg_addresses.py
@@ -15,7 +15,8 @@ class LuxembourgAddresses:
     delimiter: str = ";"
 
     def get(self) -> pl.DataFrame:
-        r = httpx.get(self.url)
+        r = httpx.get(self.url, follow_redirects=True)
+        r.raise_for_status()
         r.encoding = "utf-8-sig"
         text = r.text
         df = pl.read_csv(

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -17,13 +17,17 @@ def run_source(monkeypatch):
             class Resp:
                 def __init__(self, content):
                     self.content = content
-            monkeypatch.setattr(httpx, "get", lambda url: Resp(response))
+                def raise_for_status(self):
+                    pass
+            monkeypatch.setattr(httpx, "get", lambda url, **kwargs: Resp(response))
         else:
             class Resp:
                 def __init__(self, text):
                     self.text = text
                     self.encoding = "utf-8-sig"
-            monkeypatch.setattr(httpx, "get", lambda url: Resp(response))
+                def raise_for_status(self):
+                    pass
+            monkeypatch.setattr(httpx, "get", lambda url, **kwargs: Resp(response))
         tmp = tempfile.NamedTemporaryFile(delete=False)
         tmp.close()
         argv = ["csventrifuge.py", module, tmp.name]


### PR DESCRIPTION
## Summary
- follow HTTP redirects when downloading the Luxembourg addresses dataset
- update tests to support new `httpx.get` options

## Testing
- `pytest -q`
- `python3 csventrifuge.py luxembourg_addresses luxembourg-addresses.csv`


------
https://chatgpt.com/codex/tasks/task_e_6847288fcaf8832fb8f016bab9fb224b