### PR TITLE
Fix tuple source to return DataFrame

### DIFF
--- a/sources/luxembourg_addresses.py
+++ b/sources/luxembourg_addresses.py
@@ -15,7 +15,8 @@ class LuxembourgAddresses:
     delimiter: str = ";"
 
     def get(self) -> pl.DataFrame:
-        r = httpx.get(self.url)
+        r = httpx.get(self.url, follow_redirects=True)
+        r.raise_for_status()
         r.encoding = "utf-8-sig"
         text = r.text
         df = pl.read_csv(

--- a/sources/test_tuple_source.py
+++ b/sources/test_tuple_source.py
@@ -1,0 +1,14 @@
+from dataclasses import dataclass
+
+import polars as pl
+
+@dataclass
+class TestTupleSource:
+    delimiter: str = ","
+    __test__ = False
+
+    def get(self):
+        return pl.DataFrame({"foo": ["bar"]}).with_columns(pl.all().cast(pl.String))
+
+def get():
+    return TestTupleSource().get()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -17,13 +17,17 @@ def run_source(monkeypatch):
             class Resp:
                 def __init__(self, content):
                     self.content = content
-            monkeypatch.setattr(httpx, "get", lambda url: Resp(response))
+                def raise_for_status(self):
+                    pass
+            monkeypatch.setattr(httpx, "get", lambda url, **kwargs: Resp(response))
         else:
             class Resp:
                 def __init__(self, text):
                     self.text = text
                     self.encoding = "utf-8-sig"
-            monkeypatch.setattr(httpx, "get", lambda url: Resp(response))
+                def raise_for_status(self):
+                    pass
+            monkeypatch.setattr(httpx, "get", lambda url, **kwargs: Resp(response))
         tmp = tempfile.NamedTemporaryFile(delete=False)
         tmp.close()
         argv = ["csventrifuge.py", module, tmp.name]

--- a/tests/test_tuple_source.py
+++ b/tests/test_tuple_source.py
@@ -1,0 +1,6 @@
+from .conftest import run_source
+
+
+def test_tuple_source(run_source):
+    produced = run_source("test_tuple_source", "")
+    assert produced == [{"foo": "bar"}]


### PR DESCRIPTION
## Summary
- revert generic tuple conversion
- return a proper DataFrame in the test tuple source

## Testing
- `pytest -q`
- `python3 ./csventrifuge.py test_tuple_source test.csv && cat test.csv`


------
https://chatgpt.com/codex/tasks/task_e_6847288fcaf8832fb8f016bab9fb224b